### PR TITLE
Warnings and cleanup

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,8 @@
+[
+  inputs: [
+    "test/**/*.{ex,exs}",
+    "lib/**/*.{ex,exs}",
+    "mix.exs"
+  ],
+  line_length: 80,
+]

--- a/lib/hlclock.ex
+++ b/lib/hlclock.ex
@@ -3,7 +3,7 @@ defmodule HLClock do
   Hybrid Logical Clock
 
   Provides globally-unique, monotonic timestamps. Timestamps are bounded by the
-  clock synchronization constraint, max_drift.
+  clock synchronization constraint, `max_drift`.
 
   In order to account for physical time drift within the system, timestamps
   should regularly be exchanged between nodes. Generate a timestamp at one node
@@ -33,7 +33,7 @@ defmodule HLClock do
   end
 
   @doc """
-  Functionally equivalent to using send_timestamp. This generates a timestamp
+  Functionally equivalent to using `send_timestamp/0`. This generates a timestamp
   for local causality tracking.
   """
   def now do

--- a/lib/hlclock.ex
+++ b/lib/hlclock.ex
@@ -1,6 +1,5 @@
 defmodule HLClock do
   @moduledoc """
-
   Hybrid Logical Clock
 
   Provides globally-unique, monotonic timestamps. Timestamps are bounded by the

--- a/lib/hlclock/application.ex
+++ b/lib/hlclock/application.ex
@@ -3,7 +3,7 @@ defmodule HLClock.Application do
 
   def start(_type, _opts) do
     children = [
-      {HLClock.Server, []},
+      {HLClock.Server, []}
     ]
 
     opts = [strategy: :one_for_one]

--- a/lib/hlclock/node_id.ex
+++ b/lib/hlclock/node_id.ex
@@ -1,7 +1,7 @@
 defmodule HLClock.NodeId do
   def hash(name \\ Node.self()) do
     name
-    |> Atom.to_string
-    |> :erlang.phash2
+    |> Atom.to_string()
+    |> :erlang.phash2()
   end
 end

--- a/lib/hlclock/server.ex
+++ b/lib/hlclock/server.ex
@@ -42,7 +42,7 @@ defmodule HLClock.Server do
     end
   end
 
-  defp physical_time, do: System.os_time(:milliseconds)
+  defp physical_time, do: System.os_time(:millisecond)
 
   defp default_counter, do: 0
 

--- a/lib/hlclock/server.ex
+++ b/lib/hlclock/server.ex
@@ -5,7 +5,7 @@ defmodule HLClock.Server do
 
   def start_link(opts \\ []) do
     opts = build_opts(opts)
-    GenServer.start_link(__MODULE__, opts, [name: opts[:name]])
+    GenServer.start_link(__MODULE__, opts, name: opts[:name])
   end
 
   def init(opts) do
@@ -17,6 +17,7 @@ defmodule HLClock.Server do
     case Timestamp.send(timestamp, physical_time()) do
       {:ok, timestamp} ->
         {:reply, {:ok, timestamp}, timestamp}
+
       {:error, error} ->
         {:reply, {:error, error}, timestamp}
     end
@@ -26,6 +27,7 @@ defmodule HLClock.Server do
     case Timestamp.recv(old_time, new_time, physical_time()) do
       {:ok, timestamp} ->
         {:reply, {:ok, timestamp}, timestamp}
+
       {:error, error} ->
         {:reply, {:error, error}, old_time}
     end
@@ -33,6 +35,7 @@ defmodule HLClock.Server do
 
   def handle_info(:periodic_send, timestamp) do
     Process.send_after(self(), :periodic_send, interval())
+
     case Timestamp.send(timestamp, physical_time()) do
       {:ok, timestamp} ->
         {:noreply, timestamp}
@@ -55,8 +58,9 @@ defmodule HLClock.Server do
     |> Keyword.merge(opts)
   end
 
-  defp base_opts, do: [
-    node_id: Application.get_env(:hlclock, :node_id, fn -> NodeId.hash() end),
-    name: __MODULE__
-  ]
+  defp base_opts,
+    do: [
+      node_id: Application.get_env(:hlclock, :node_id, fn -> NodeId.hash() end),
+      name: __MODULE__
+    ]
 end

--- a/lib/hlclock/timestamp.ex
+++ b/lib/hlclock/timestamp.ex
@@ -93,21 +93,22 @@ defmodule HLClock.Timestamp do
   Create a millisecond granularity DateTime struct representing the logical time
   portion of the Timestamp.
 
-  Given that this representation loses the logical counter and node information,
+  Given that this representation looses the logical counter and node information,
   it should be used as a reference only. Including the counter in the DateTime
   struct would create absurd but still ordered timestamps.
 
   ## Example
 
-  iex> {:ok, _t0} = HLClock.Timestamp.new(1410652800000, 0, 0)
-  {:ok, %HLClock.Timestamp{counter: 0, node_id: 0, time: 1410652800000}}
+      iex> {:ok, t0} = HLClock.Timestamp.new(1410652800000, 0, 0)
+      {:ok, %HLClock.Timestamp{counter: 0, node_id: 0, time: 1410652800000}}
 
-  ...> encoded = HLClock.Timestamp.encode(t0)
-  <<1, 72, 113, 117, 132, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
-  ...> << time_and_counter :: size(64), _ :: size(64) >> = encoded
+      iex> encoded = HLClock.Timestamp.encode(t0)
+      <<1, 72, 113, 117, 132, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
 
-  ...> DateTime.from_unix(time_and_counter, :microsecond)
-  {:ok, #DateTime<4899-07-30 06:31:40.800000Z>}
+      iex> << time_and_counter :: size(64), _ :: size(64) >> = encoded
+
+      iex> DateTime.from_unix(time_and_counter, :microsecond)
+      {:ok, #DateTime<4899-07-30 06:31:40.800000Z>}
   """
   def to_datetime(%T{time: t}) do
     with {:ok, dt} <- DateTime.from_unix(t, :millisecond) do

--- a/lib/hlclock/timestamp.ex
+++ b/lib/hlclock/timestamp.ex
@@ -99,15 +99,16 @@ defmodule HLClock.Timestamp do
 
   ## Example
 
-      iex> {:ok, t0} = HLClock.Timestamp.new(1410652800000, 0, 0)
+      iex> {:ok, _t0} = HLClock.Timestamp.new(1410652800000, 0, 0)
       {:ok, %HLClock.Timestamp{counter: 0, node_id: 0, time: 1410652800000}}
 
-      iex> encoded = HLClock.Timestamp.encode(t0)
+      ...> encoded = HLClock.Timestamp.encode(t0)
       <<1, 72, 113, 117, 132, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
 
-      iex> << time_and_counter :: size(64), _ :: size(64) >> = encoded
+      ...> << time_and_counter :: size(64), _ :: size(64) >> = encoded
+      <<1, 72, 113, 117, 132, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
 
-      iex> DateTime.from_unix(time_and_counter, :microsecond)
+      ...> DateTime.from_unix(time_and_counter, :microsecond)
       {:ok, #DateTime<4899-07-30 06:31:40.800000Z>}
   """
   def to_datetime(%T{time: t}) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,18 +4,19 @@ defmodule HLClock.Mixfile do
   @version "0.1.6"
 
   def project do
-    [app: :hlclock,
-     version: @version,
-     elixir: "~> 1.5",
-     elixirc_paths: elixirc_paths(Mix.env),
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     description: description(),
-     package: package(),
-     deps: deps(),
-     name: "HLClock",
-     source_url: "https://github.com/toniqsystems/hlclock",
-   ]
+    [
+      app: :hlclock,
+      version: @version,
+      elixir: "~> 1.5",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      description: description(),
+      package: package(),
+      deps: deps(),
+      name: "HLClock",
+      source_url: "https://github.com/toniqsystems/hlclock"
+    ]
   end
 
   def application do
@@ -32,7 +33,7 @@ defmodule HLClock.Mixfile do
   defp deps do
     [
       {:stream_data, "~> 0.2", only: [:test, :dev]},
-      {:ex_doc, "~> 0.16", only: :dev},
+      {:ex_doc, "~> 0.19", only: :dev}
     ]
   end
 
@@ -48,7 +49,7 @@ defmodule HLClock.Mixfile do
       files: ["lib", "mix.exs", "README.md"],
       maintainers: ["Chris Keathley", "Neil Menne"],
       licenses: ["Apache 2.0"],
-      links: %{"GitHub" => "https://github.com/toniqsystems/hlclock"},
+      links: %{"GitHub" => "https://github.com/toniqsystems/hlclock"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,8 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "stream_data": {:hex, :stream_data, "0.2.0", "887b7701cd4ea235e0d704ce60f86096ff5754dae55c3ead4e1d43f152a9239e", [:mix], [], "hexpm"}}
+%{
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "stream_data": {:hex, :stream_data, "0.2.0", "887b7701cd4ea235e0d704ce60f86096ff5754dae55c3ead4e1d43f152a9239e", [:mix], [], "hexpm"},
+}

--- a/test/hlclock/server_test.exs
+++ b/test/hlclock/server_test.exs
@@ -4,7 +4,10 @@ defmodule HLClock.ServerTest do
   describe "node names" do
     test "HLClocks can be given a node id" do
       node_id = fn -> 12345 end
-      {:ok, hlc} = HLClock.Server.start_link(node_id: node_id, name: :given_node_id)
+
+      {:ok, hlc} =
+        HLClock.Server.start_link(node_id: node_id, name: :given_node_id)
+
       {:ok, clock} = GenServer.call(hlc, :send_timestamp)
       assert %{node_id: 12345} = clock
     end

--- a/test/hlclock/timestamp_test.exs
+++ b/test/hlclock/timestamp_test.exs
@@ -31,33 +31,34 @@ defmodule HLClock.TimestampTest do
     property "encoded timestamps maintains ordering" do
       check all timestamps <- list_of(timestamp()) do
         assert timestamps
-        |> Enum.map(&Timestamp.encode/1)
-        |> Enum.sort()
-        |> Enum.map(&Timestamp.decode/1) == Enum.sort(timestamps, &Timestamp.before?/2)
+               |> Enum.map(&Timestamp.encode/1)
+               |> Enum.sort()
+               |> Enum.map(&Timestamp.decode/1) ==
+                 Enum.sort(timestamps, &Timestamp.before?/2)
       end
     end
 
     property "encoding and decoding are inversions" do
       check all hlc <- timestamp() do
         assert hlc
-        |> Timestamp.encode
-        |> Timestamp.decode == hlc
+               |> Timestamp.encode()
+               |> Timestamp.decode() == hlc
       end
     end
 
     property "to_string/1" do
       check all hlc <- timestamp() do
         assert hlc
-        |> to_string
-        |> String.length == 46
+               |> to_string
+               |> String.length() == 46
       end
     end
 
     property "to_string/1 and from_string/1 are symmetric" do
       check all hlc <- timestamp() do
         assert hlc
-        |> to_string
-        |> Timestamp.from_string == hlc
+               |> to_string
+               |> Timestamp.from_string() == hlc
       end
     end
   end
@@ -97,7 +98,7 @@ defmodule HLClock.TimestampTest do
     end
 
     test "send can fail due to excessive drift" do
-      {:ok, t0}     = Timestamp.new(0, 0)
+      {:ok, t0} = Timestamp.new(0, 0)
       {:error, err} = Timestamp.send(t0, HLClock.max_drift() + 1)
       assert err == :clock_drift_violation
     end
@@ -127,14 +128,15 @@ defmodule HLClock.TimestampTest do
         {8, :recv, timestamp(10, 4, 1), timestamp(10, 8, 0)},
 
         # Faulty clock should be discarded
-        {9, :recv, timestamp(HLClock.max_drift()+10+1, 888, 1), timestamp(10, 8, 0)},
+        {9, :recv, timestamp(HLClock.max_drift() + 10 + 1, 888, 1),
+         timestamp(10, 8, 0)},
 
         # Wall clocks coincide but remote logical clock wins
         {10, :recv, timestamp(10, 99, 1), timestamp(10, 100, 0)},
 
         # The physical clock has caught up and takes over
         {11, :recv, timestamp(10, 31, 1), timestamp(11, 0, 0)},
-        {11, :send, nil, timestamp(11, 1, 0)},
+        {11, :send, nil, timestamp(11, 1, 0)}
       ]
 
       events
@@ -146,6 +148,7 @@ defmodule HLClock.TimestampTest do
     case Timestamp.new(time, counter, node_id) do
       {:ok, timestamp} ->
         timestamp
+
       _ ->
         :error
     end
@@ -161,6 +164,7 @@ defmodule HLClock.TimestampTest do
     case run_event(event, current, input, wall_time) do
       {:ok, next_clock} ->
         next_clock
+
       {:error, :remote_drift_violation} ->
         current
     end
@@ -170,6 +174,7 @@ defmodule HLClock.TimestampTest do
     case event do
       :send ->
         Timestamp.send(current, wall_time)
+
       :recv ->
         Timestamp.recv(current, input, wall_time)
     end

--- a/test/hlclock_test.exs
+++ b/test/hlclock_test.exs
@@ -16,7 +16,8 @@ defmodule HLClockTest do
   describe "recv_timestamp/1" do
     test "works" do
       {:ok, clock} = HLClock.send_timestamp()
-      clock = %{clock | node_id: 12345} # pretend to be from another node
+      # pretend to be from another node
+      clock = %{clock | node_id: 12345}
       :timer.sleep(100)
       {:ok, new_clock} = HLClock.recv_timestamp(clock)
 

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -6,12 +6,13 @@ defmodule HLClock.Generators do
   @max_node_size 18_446_744_073_709_551_615
   @max_counter_size 65_535
   @max_time_size 281_474_976_710_655
-  @max_time_value 253_402_300_799_999 # 9999-12-31T23:59:59.999Z
+  # 9999-12-31T23:59:59.999Z
+  @max_time_value 253_402_300_799_999
 
   def ntp_millis, do: integer(0..@max_time_size)
 
   def int_of_size(size) do
-    bind(bitstring(length: size), fn(<<n :: integer-size(size)>>) ->
+    bind(bitstring(length: size), fn <<n::integer-size(size)>> ->
       constant(n)
     end)
   end
@@ -29,7 +30,7 @@ defmodule HLClock.Generators do
   def large_node_id, do: large_integer(max_node())
   def large_counter, do: large_integer(max_counter())
 
-  def large_integer(value), do: integer((value+1)..(value*2))
+  def large_integer(value), do: integer((value + 1)..(value * 2))
 
   def max_node, do: @max_node_size
   def max_time_size, do: @max_time_size


### PR DESCRIPTION
I was working on moving another project to elixir 1.8, and I saw a warning about `:milliseconds` here. I thought I'd get that "easy win" and do some other minor changes to make this project more in line with others we maintain.

Changing `stream_data` versions was not as clean, so I deferred that for now.