### PR TITLE
Re-write hlclock to require starting in the users supervision tree

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-elixir 1.5.1
+elixir 1.9.1

--- a/lib/hlclock.ex
+++ b/lib/hlclock.ex
@@ -3,7 +3,8 @@ defmodule HLClock do
   Hybrid Logical Clock
 
   Provides globally-unique, monotonic timestamps. Timestamps are bounded by the
-  clock synchronization constraint, `max_drift`.
+  clock synchronization constraint, max_drift. By default the max_drift is set
+  to 300 seconds.
 
   In order to account for physical time drift within the system, timestamps
   should regularly be exchanged between nodes. Generate a timestamp at one node
@@ -12,38 +13,44 @@ defmodule HLClock do
 
   Inspired by https://www.cse.buffalo.edu/tech-reports/2014-04.pdf
   """
-
   alias HLClock.Timestamp
+
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      type: :worker,
+      start: {__MODULE__, :start_link, [opts]}
+    }
+  end
+
+  def start_link(opts \\ []) do
+    HLClock.Server.start_link(opts)
+  end
 
   @doc """
   Generate a single HLC Timestamp for sending to other nodes or
   local causality tracking
   """
-  def send_timestamp do
-    GenServer.call(HLClock.Server, :send_timestamp)
+  def send_timestamp(server) do
+    GenServer.call(server, :send_timestamp)
   end
 
   @doc """
   Given the current timestamp for this node and a provided remote timestamp,
   perform the merge of both logical time and logical counters. Returns the new
-  current timestamp for the local node
+  current timestamp for the local node.
   """
-  def recv_timestamp(remote) do
-    GenServer.call(HLClock.Server, {:recv_timestamp, remote})
+  def recv_timestamp(server, remote) do
+    GenServer.call(server, {:recv_timestamp, remote})
   end
 
   @doc """
   Functionally equivalent to using `send_timestamp/0`. This generates a timestamp
   for local causality tracking.
   """
-  def now do
-    GenServer.call(HLClock.Server, :send_timestamp)
+  def now(server) do
+    GenServer.call(server, :send_timestamp)
   end
-
-  @doc """
-  Configurable clock synchronization parameter, ε. Defaults to 300 seconds
-  """
-  def max_drift(), do: Application.get_env(:hlclock, :max_drift_millis, 300_000)
 
   @doc """
   Determines if the clock's timestamp "happened before" a different timestamp

--- a/lib/hlclock/server.ex
+++ b/lib/hlclock/server.ex
@@ -1,57 +1,84 @@
 defmodule HLClock.Server do
+  @moduledoc false
   use GenServer
 
   alias HLClock.{NodeId, Timestamp}
 
+  @gen_server_opts [
+    :debug,
+    :name,
+    :timeout,
+    :spawn_opt,
+    :hibernate_after
+  ]
+
   def start_link(opts \\ []) do
-    opts = build_opts(opts)
-    GenServer.start_link(__MODULE__, opts, name: opts[:name])
+    {gen_server_opts, other_opts} = Keyword.split(opts, @gen_server_opts)
+
+    hlc_opts = build_opts(other_opts)
+    GenServer.start_link(__MODULE__, hlc_opts, gen_server_opts)
   end
 
   def init(opts) do
-    Process.send_after(self(), :periodic_send, interval())
-    Timestamp.new(physical_time(), default_counter(), node_id(opts))
+    node_id = node_id(opts)
+    initial_counter = 0
+
+    data = %{
+      node_id: node_id,
+      timestamp: Timestamp.new(physical_time(), initial_counter, node_id),
+      max_drift: opts[:max_drift]
+    }
+
+    Process.send_after(self(), :periodic_send, interval(data))
+    {:ok, data}
   end
 
-  def handle_call(:send_timestamp, _from, timestamp) do
-    case Timestamp.send(timestamp, physical_time()) do
+  def handle_call(:send_timestamp, _from, data) do
+    case Timestamp.send(data.timestamp, physical_time(), data.max_drift) do
       {:ok, timestamp} ->
-        {:reply, {:ok, timestamp}, timestamp}
+        {:reply, {:ok, timestamp}, %{data | timestamp: timestamp}}
 
       {:error, error} ->
-        {:reply, {:error, error}, timestamp}
+        {:reply, {:error, error}, data}
     end
   end
 
-  def handle_call({:recv_timestamp, new_time}, _from, old_time) do
-    case Timestamp.recv(old_time, new_time, physical_time()) do
+  def handle_call(
+        {:recv_timestamp, new_time},
+        _from,
+        %{timestamp: old_time, max_drift: max_drift} = data
+      ) do
+    case Timestamp.recv(old_time, new_time, physical_time(), max_drift) do
       {:ok, timestamp} ->
-        {:reply, {:ok, timestamp}, timestamp}
+        {:reply, {:ok, timestamp}, %{data | timestamp: timestamp}}
 
       {:error, error} ->
-        {:reply, {:error, error}, old_time}
+        {:reply, {:error, error}, data}
     end
   end
 
-  def handle_info(:periodic_send, timestamp) do
-    Process.send_after(self(), :periodic_send, interval())
+  def handle_info(:periodic_send, data) do
+    Process.send_after(self(), :periodic_send, interval(data))
 
-    case Timestamp.send(timestamp, physical_time()) do
-      {:ok, timestamp} ->
-        {:noreply, timestamp}
+    case Timestamp.send(data.timestamp, physical_time(), data.max_drift) do
+      {:ok, ts} ->
+        {:noreply, %{data | timestamp: ts}}
 
-      {:error, _err} ->
-        {:noreply, timestamp}
+      {:error, _} ->
+        {:noreply, data}
     end
   end
 
   defp physical_time, do: System.os_time(:millisecond)
 
-  defp default_counter, do: 0
+  defp interval(%{max_drift: max_drift}), do: round(max_drift / 2)
 
-  defp node_id([{:node_id, fun} | _]) when is_function(fun), do: fun.()
-
-  defp interval, do: round(HLClock.max_drift() / 2)
+  defp node_id(opts) do
+    case opts[:node_id] do
+      f when is_function(f) -> f.()
+      other -> other
+    end
+  end
 
   defp build_opts(opts) do
     base_opts()
@@ -60,7 +87,8 @@ defmodule HLClock.Server do
 
   defp base_opts,
     do: [
-      node_id: Application.get_env(:hlclock, :node_id, fn -> NodeId.hash() end),
-      name: __MODULE__
+      name: __MODULE__,
+      node_id: NodeId.hash(),
+      max_drift: 300_000
     ]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,6 @@ defmodule HLClock.Mixfile do
 
   def application do
     [
-      mod: {HLClock.Application, []},
       extra_applications: [:logger]
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,6 @@
-%{
-  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
-  "stream_data": {:hex, :stream_data, "0.2.0", "887b7701cd4ea235e0d704ce60f86096ff5754dae55c3ead4e1d43f152a9239e", [:mix], [], "hexpm"},
-}
+%{"earmark": {:hex, :earmark, "1.3.5", "0db71c8290b5bc81cb0101a2a507a76dca659513984d683119ee722828b424f6", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.21.1", "5ac36660846967cd869255f4426467a11672fec3d8db602c429425ce5b613b90", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
+  "stream_data": {:hex, :stream_data, "0.4.3", "62aafd870caff0849a5057a7ec270fad0eb86889f4d433b937d996de99e3db25", [:mix], [], "hexpm"}}

--- a/test/hlclock/node_id_test.exs
+++ b/test/hlclock/node_id_test.exs
@@ -1,12 +1,12 @@
 defmodule HLClock.NodeIdTest do
   use ExUnit.Case, async: true
-  import PropertyTest
+  use ExUnitProperties
   import StreamData
 
   alias HLClock.{NodeId, Generators}
 
   property "Hashed node ids are within the correct bounds" do
-    check all node_name <- unquoted_atom() do
+    check all(node_name <- atom(:alphanumeric)) do
       hash = NodeId.hash(node_name)
       assert 0 <= hash && hash <= Generators.max_node()
     end

--- a/test/hlclock/server_test.exs
+++ b/test/hlclock/server_test.exs
@@ -12,14 +12,6 @@ defmodule HLClock.ServerTest do
       assert %{node_id: 12345} = clock
     end
 
-    test "can be added in a config" do
-      Application.put_env(:hlclock, :node_id, fn -> 1337 end)
-      {:ok, hlc} = HLClock.Server.start_link(name: :config_node_id)
-      {:ok, clock} = GenServer.call(hlc, :send_timestamp)
-      Application.delete_env(:hlclock, :node_id)
-      assert %{node_id: 1337} = clock
-    end
-
     test "if no node id is given then we use a hash of the node name" do
       {:ok, hlc} = HLClock.Server.start_link(name: :no_node_id)
       {:ok, clock} = GenServer.call(hlc, :send_timestamp)

--- a/test/hlclock_test.exs
+++ b/test/hlclock_test.exs
@@ -1,11 +1,17 @@
 defmodule HLClockTest do
   use ExUnit.Case, async: false
 
+  setup do
+    {:ok, pid} = HLClock.start_link()
+
+    {:ok, hlc: pid}
+  end
+
   describe "send_timestamp/0" do
-    test "uses system time by default" do
-      {:ok, clock} = HLClock.send_timestamp()
+    test "uses system time by default", %{hlc: hlc} do
+      {:ok, clock} = HLClock.send_timestamp(hlc)
       :timer.sleep(100)
-      {:ok, new_clock} = HLClock.send_timestamp()
+      {:ok, new_clock} = HLClock.send_timestamp(hlc)
 
       assert HLClock.before?(clock, new_clock)
       refute HLClock.before?(new_clock, clock)
@@ -14,16 +20,32 @@ defmodule HLClockTest do
   end
 
   describe "recv_timestamp/1" do
-    test "works" do
-      {:ok, clock} = HLClock.send_timestamp()
+    test "works", %{hlc: hlc} do
+      {:ok, clock} = HLClock.send_timestamp(hlc)
       # pretend to be from another node
       clock = %{clock | node_id: 12345}
       :timer.sleep(100)
-      {:ok, new_clock} = HLClock.recv_timestamp(clock)
+      {:ok, new_clock} = HLClock.recv_timestamp(hlc, clock)
 
       assert HLClock.before?(clock, new_clock)
       refute HLClock.before?(new_clock, clock)
       assert new_clock.counter == 0
     end
+  end
+
+  test "servers can be named" do
+    assert {:ok, _} = HLClock.start_link(name: :my_clock)
+    assert {:ok, _ts} = HLClock.send_timestamp(:my_clock)
+  end
+
+  test "node_id can be assigned as an option" do
+    node_id =
+      8
+      |> :crypto.strong_rand_bytes()
+      |> :crypto.bytes_to_integer()
+
+    assert {:ok, hlc} = HLClock.start_link(node_id: node_id)
+    assert {:ok, ts} = HLClock.send_timestamp(hlc)
+    assert ts.node_id == node_id
   end
 end

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -1,4 +1,5 @@
 defmodule HLClock.Generators do
+  use ExUnitProperties
   import StreamData
 
   alias HLClock.Timestamp
@@ -18,13 +19,20 @@ defmodule HLClock.Generators do
   end
 
   def timestamp do
-    gen all time <- integer(0..max_time_value()),
-            counter <- integer(0..max_counter()),
-            node_id <- integer(0..max_node()) do
-      {:ok, timestamp} = Timestamp.new(time, counter, node_id)
-      timestamp
+    gen all(
+          time <- gen_time(),
+          counter <- gen_counter(),
+          node_id <- gen_node_id()
+        ) do
+      Timestamp.new(time, counter, node_id)
     end
   end
+
+  def gen_time, do: integer(0..max_time_value())
+
+  def gen_counter, do: integer(0..max_counter())
+
+  def gen_node_id, do: integer(0..max_node())
 
   def large_time, do: large_integer(max_time_size())
   def large_node_id, do: large_integer(max_node())


### PR DESCRIPTION
I've converted HLClock away from an application and re-worked things so that HLClock can be started in the user's supervision tree.